### PR TITLE
Support dialogs on Android

### DIFF
--- a/inspector/an-inspector/ForgeModule/src/io/trigger/forge/android/modules/actionsheet/API.java
+++ b/inspector/an-inspector/ForgeModule/src/io/trigger/forge/android/modules/actionsheet/API.java
@@ -1,0 +1,35 @@
+package io.trigger.forge.android.modules.actionsheet;
+
+import io.trigger.forge.android.core.ForgeApp;
+import io.trigger.forge.android.core.ForgeParam;
+import io.trigger.forge.android.core.ForgeTask;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+public class API {
+	public static void show(final ForgeTask task,
+			@ForgeParam("text") final String text,
+			@ForgeParam("destructiveTitle") final String destructiveTitle,
+			@ForgeParam("cancelTitle") final String cancelTitle){
+		
+		task.performUI(new Runnable(){
+			@Override
+			public void run() {
+				new AlertDialog.Builder(ForgeApp.getActivity())
+					.setTitle("")
+					.setMessage(text)
+					.setPositiveButton(destructiveTitle, new DialogInterface.OnClickListener() {
+						public void onClick(DialogInterface dialog, int which) { 
+							ForgeApp.event("actionsheet.destructive");
+						}
+					 })
+					.setNegativeButton(cancelTitle, new DialogInterface.OnClickListener() {
+						public void onClick(DialogInterface dialog, int which) { 
+							ForgeApp.event("actionsheet.cancel");
+						}
+					 })
+					.show();
+			}});
+		task.success();
+	}
+}

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -1,6 +1,8 @@
 {
-    "description": "Multiple ",
-    "name": "actionsheet",
-    "platform_version": "v2.0.0",
-    "version": "1.0.2"
+	"description": "Display dialog prompts",
+	"namespace": "actionsheet",
+	"min_platform_version": "v2.2.2",
+	"platform_version": "v2.2.2",
+	"version": "2.0.0",
+	"changes": "Add Android support"
 }

--- a/module/tests/automated.js
+++ b/module/tests/automated.js
@@ -2,12 +2,20 @@ module("actionsheet");
 
 // In this test we call the example showAlert API method with an empty string
 // In the example API method an empty string will immediately call the error callback
-asyncTest("Attempt to show an alert with no text", 1, function() {
-	forge.actionsheet.showAlert("", function () {
-		ok(false, "Expected failure, got success");
+asyncTest("Display a dialog", 1, function() {
+	var success = function(){
+		ok(true, "You clicked a button!");
 		start();
-	}, function () {
-		ok(true, "Expected failure");
+	};
+	forge.internal.call('actionsheet.show', {
+		text: "Press a button!",
+		destructiveTitle: "Test!",
+		cancelTitle: "Another test."
+	}, function() {
+		forge.internal.addEventListener('actionsheet.destructive', success);
+		forge.internal.addEventListener('actionsheet.cancel', success);
+	}, function(e){
+		ok(false, e);
 		start();
 	});
 });


### PR DESCRIPTION
The Android implementation of this module displays a modal popup like this:

![image](https://cloud.githubusercontent.com/assets/1661138/8661908/35b8611c-2989-11e5-998d-adab1e9c594a.png)

While the UI is slightly different than the iOS implementation, it provides the same functionality.